### PR TITLE
fix(controller): :bug: fix set qurban event data to redux store

### DIFF
--- a/src/controllers/qurban-event/admin/find/get-resource-data.client.hooks.ts
+++ b/src/controllers/qurban-event/admin/find/get-resource-data.client.hooks.ts
@@ -40,7 +40,10 @@ export function useControllerQurbanEventAdminFindGetResourceDataClient<
     const response = await remoteService.get<{ data: DataType[] }>('/qurban_events', { params: { query }})
     const data = response?.data?.data ?? []
     if (qurbanEventId && qurbanEventDataIsEmpty) {
-      dispatch(setQurbanEventData(data[0]))
+      const selectedQurbanEventData = data?.find((item) =>
+        item.id === qurbanEventId
+      ) ?? null
+      dispatch(setQurbanEventData(selectedQurbanEventData))
     }
     setData(data)
   }


### PR DESCRIPTION
previously when app call qurban event endpoint, app always store first index of qurban events data. this will be probilematic if one mosque has more than 1 qurban events. this controller will filter saved qurban events data with specific id, then store it into redux store

fix #8